### PR TITLE
Do not resolve quarkus classpath if generate app model task is UP-TO-DATE

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -19,6 +20,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.plugins.JavaPlugin;
@@ -75,24 +77,36 @@ public class ApplicationDeploymentClasspathBuilder {
         // Base runtime configurations for every launch mode
         configContainer
                 .register(ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(LaunchMode.TEST), config -> {
-                    config.extendsFrom(configContainer.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+                    config.extendsFrom(getOriginalRuntimeClasspaths(project, LaunchMode.TEST));
                     config.setCanBeConsumed(false);
                 });
 
         configContainer
                 .register(ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(LaunchMode.NORMAL), config -> {
-                    config.extendsFrom(configContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+                    config.extendsFrom(getOriginalRuntimeClasspaths(project, LaunchMode.NORMAL));
                     config.setCanBeConsumed(false);
                 });
 
         configContainer
                 .register(ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(LaunchMode.DEVELOPMENT), config -> {
-                    config.extendsFrom(
-                            configContainer.getByName(ToolingUtils.DEV_MODE_CONFIGURATION_NAME),
-                            configContainer.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME),
-                            configContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+                    config.extendsFrom(getOriginalRuntimeClasspaths(project, LaunchMode.DEVELOPMENT));
                     config.setCanBeConsumed(false);
                 });
+    }
+
+    private static Configuration[] getOriginalRuntimeClasspaths(Project project, LaunchMode mode) {
+        List<String> configurationNames = switch (mode) {
+            case TEST -> List.of(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            case NORMAL -> List.of(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            case DEVELOPMENT -> List.of(
+                    ToolingUtils.DEV_MODE_CONFIGURATION_NAME,
+                    JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
+                    JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        };
+        ConfigurationContainer configContainer = project.getConfigurations();
+        return configurationNames.stream()
+                .map(configContainer::getByName)
+                .toArray(Configuration[]::new);
     }
 
     private final Project project;
@@ -239,6 +253,10 @@ public class ApplicationDeploymentClasspathBuilder {
                 config.setCanBeConsumed(false);
             });
         }
+    }
+
+    public FileCollection getOriginalRuntimeClasspathAsInput() {
+        return project.files((Object[]) getOriginalRuntimeClasspaths(project, mode));
     }
 
     public Configuration getPlatformConfiguration() {


### PR DESCRIPTION
This change **_should_** improve build time a bit when `quarkusGenerateAppModel` tasks are `UP-TO-DATE` for no configuration cache case.

We try to avoid resolving quarkus classpaths by having only original classpaths as an input from which quarkus classpaths are calculated instead of quarkus classpaths themself.

In a build scan I still see that some quarkus configurations are resolved during configuration if `quarkusGenerateAppModel` is `UP-TO-DATE`, but these are pretty fast:
 <img width="469" alt="Screenshot 2024-05-05 at 21 09 22" src="https://github.com/cdsap/quarkus/assets/3939893/fcf4e820-6a3a-46f1-bb18-ef7c4c71db6f">
 
Compared to the version before where it was:
<img width="473" alt="Screenshot 2024-05-05 at 21 16 05" src="https://github.com/cdsap/quarkus/assets/3939893/725e937b-77fd-4b56-8611-a6cb3b43313e">
 